### PR TITLE
Hide public Jobs tab for authenticated users

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -69,6 +69,7 @@ const AppLayout = () => {
         />
         <Tabs.Screen
           name="jobs"
+          redirect={!isGuest}
           options={{
             headerShown: false,
             sceneStyle,


### PR DESCRIPTION
Adds redirect on the Jobs tab so it is only visible to guest users.