### PR TITLE
Fix native splash screen

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,8 +37,7 @@
       [
         "expo-splash-screen",
         {
-          "backgroundColor": "#ffffff",
-          "image": "./assets/images/splash.png"
+          "backgroundColor": "#4aafc4"
         }
       ],
       "expo-router",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -36,9 +36,9 @@ export default function RootLayout() {
         require('@/assets/images/splash-bg.png'),
         require('@/assets/images/marineria_logo_transparent.png'),
       ])
+      // Set state first so our animated splash is mounted before native splash disappears
       setAssetsLoaded(true)
-      // Hide native splash — our animated splash takes over immediately
-      await SplashScreen.hideAsync()
+      requestAnimationFrame(() => SplashScreen.hideAsync())
     }
     loadAssets()
   }, [])


### PR DESCRIPTION
## Summary
- Remove image from `expo-splash-screen` plugin config — native splash now shows solid `#4aafc4` teal, eliminating the small→full-screen jump
- Match background color between native and animated splash for a seamless handoff
- Use `requestAnimationFrame` before `SplashScreen.hideAsync()` so the custom animated splash is mounted before the native one disappears

## Test plan
- [ ] Run EAS/native build and verify no size jump on app open
- [ ] Confirm custom animated splash transitions smoothly from the native splash