### PR TITLE
Replace faker images with real photo URLs

### DIFF
--- a/api/consts.ts
+++ b/api/consts.ts
@@ -1,5 +1,9 @@
 export const BASE_URL = 'https://www.comunicazione.it'
 
+const PHOTOS_BASE_URL = process.env.EXPO_PUBLIC_PHOTOS_BASE_URL ?? 'https://test.marineria.it'
+
+export const getPhotoUrl = (filename: string) => `${PHOTOS_BASE_URL}/PROFoto/${filename}.jpg`
+
 export const API = {
   LOGIN: `${BASE_URL}/api/login`,
   CHECK_EMAIL: `${BASE_URL}/api/Login/ChekEmail`,

--- a/api/pro.ts
+++ b/api/pro.ts
@@ -28,7 +28,6 @@ type WhyCanNotApplyResponse = {
 export const getWhyCanNotApply = async (offerId: number, proToken: string, language: string): Promise<string[]> => {
   const languageCode = getLanguageCode(language)
   const url = API.WHY_CANT_APPLY + `/${offerId}/${proToken}?Language=${languageCode}`
-  console.log('Fetching why can not apply reasons from url:', offerId, proToken, languageCode)
   const data = await apiFetchJson<WhyCanNotApplyResponse>(url)
   return Array.isArray(data.reason) ? data.reason : [data.reason]
 }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 import { router } from 'expo-router'
 import { useTranslation } from 'react-i18next'
 import { TUserRole } from '@/api/types'
+import { getPhotoUrl } from '@/api/consts'
 import { useSession } from '@/Providers/SessionProvider'
 import { useUser } from '@/Providers/UserProvider'
 import {
@@ -21,11 +22,11 @@ import { ScreenContainer } from '@/components/appUI'
 const GuestWelcome = () => {
   const { t } = useTranslation('home-screen')
   return (
-    <ScreenContainer className="justify-center items-center px-6">
+    <ScreenContainer className="items-center justify-center px-6">
       <VStack space="lg" className="items-center">
-        <Heading className="text-center text-3xl text-primary-600">{t('guest-welcome')}</Heading>
-        <Text className="text-center text-typography-600 text-base">{t('guest-subtitle')}</Text>
-        <Button size="lg" className="w-full mt-4 justify-center" onPress={() => router.navigate('/(tabs)/jobs')}>
+        <Heading className="text-3xl text-center text-primary-600">{t('guest-welcome')}</Heading>
+        <Text className="text-base text-center text-typography-600">{t('guest-subtitle')}</Text>
+        <Button size="lg" className="justify-center w-full mt-4" onPress={() => router.navigate('/(tabs)/jobs')}>
           <ButtonText className="flex-1 text-center">{t('browse-offers')}</ButtonText>
         </Button>
       </VStack>
@@ -40,10 +41,11 @@ const UserProfile = () => {
   const { user, isLoading } = useUser()
   const isRecruiter = role == TUserRole.CREW
 
-  const photoUrl = useMemo(() => `https://www.marineria.it/PROFoto/${user?.namephotoA}.jpg`, [user])
+  const photoName = useMemo(() => user?.namephotoA || user?.namephotoB || user?.namephotoC, [user])
+  const photoUrl = useMemo(() => (photoName ? getPhotoUrl(photoName) : null), [photoName])
 
   return (
-    <ScreenContainer className="justify-center items-center px-2">
+    <ScreenContainer className="items-center justify-center px-2">
       {isLoading ? (
         <Loading />
       ) : (
@@ -52,10 +54,10 @@ const UserProfile = () => {
             <>
               <Box className="mb-4">
                 <Avatar size="xl">
-                  {role == TUserRole.CREW && user.namephotoA ? (
+                  {photoName ? (
                     <AvatarImage
                       source={{
-                        uri: photoUrl,
+                        uri: photoUrl ?? undefined,
                       }}
                     />
                   ) : (
@@ -64,9 +66,9 @@ const UserProfile = () => {
                 </Avatar>
               </Box>
               <Box>
-                <Heading className="text-center text-4xl">{t('welcome')}</Heading>
+                <Heading className="text-4xl text-center">{t('welcome')}</Heading>
                 <Heading className="text-4xl text-center">{user.surname}</Heading>
-                <Text className="text-xl p4 text-center my-6">
+                <Text className="my-6 text-xl text-center p4">
                   {role == TUserRole.RECRUITER && t('recruiter-message')}
                   {role == TUserRole.CREW && t('crew-message')}
                 </Text>

--- a/components/recruiter/crew/crewList/CrewListItem.tsx
+++ b/components/recruiter/crew/crewList/CrewListItem.tsx
@@ -16,8 +16,8 @@ import {
 } from '@/components/ui'
 import { User, Calendar, MapPin, Award, Heart, Cake, Cigarette, IdCard, Briefcase } from 'lucide-react-native'
 import { TCrewSimple } from '@/api/types'
-import { faker } from '@faker-js/faker'
 import { useTranslation } from 'react-i18next'
+import { getPhotoUrl } from '@/api/consts'
 import { SubSection } from '@/components/appUI'
 import { getAgeByYear } from '@/utils/dateUtils'
 import { getCertificateOfCompetence, getSeamansBook } from '@/utils/crewUtils'
@@ -31,8 +31,7 @@ const CrewListItem: FC<ICrewListItem> = ({ crew }) => {
 
   const router = useRouter()
   const { searchId } = useLocalSearchParams()
-  const photoUrl = useMemo(() => `https://www.comunicazione.it/PROFoto/${crew?.userPhoto}`, [crew])
-  const fakerImage = useMemo(() => faker.image.personPortrait({ size: 256 }), [crew])
+  const photoUrl = useMemo(() => (crew?.userPhoto ? getPhotoUrl(crew.userPhoto) : null), [crew])
   const handlePress = () => {
     router.push(`/recruiter/search/${searchId}/crew/${crew.userId}`)
   }
@@ -48,7 +47,7 @@ const CrewListItem: FC<ICrewListItem> = ({ crew }) => {
           <HStack className="items-start flex-1" space="sm">
             <Box className="w-16 h-16 rounded-md bg-primary-100 items-center justify-center overflow-hidden">
               {crew.userPhoto ? (
-                <Image source={{ uri: fakerImage }} className="w-full h-full" alt="profile" />
+                <Image source={{ uri: photoUrl ?? undefined }} className="w-full h-full" alt="profile" />
               ) : (
                 <Icon as={User} className="white" size="xl" />
               )}

--- a/components/recruiter/crew/crewProfile/ContactCrewModal.tsx
+++ b/components/recruiter/crew/crewProfile/ContactCrewModal.tsx
@@ -23,8 +23,8 @@ import {
 import { User, Unlock, FileText, Send, Check, PhoneCall } from 'lucide-react-native'
 import { SubSection } from '@/components/appUI'
 import { TCrew } from '@/api/types'
-import { faker } from '@faker-js/faker'
 import { useTranslation } from 'react-i18next'
+import { getPhotoUrl } from '@/api/consts'
 import { useRecruiterSearch } from '@/Providers/RecruiterSearchProvider'
 import ContactModalUnpaid from './ContactModalUnpaid'
 import { useAuthBrowser } from '@/hooks'
@@ -37,7 +37,7 @@ interface IContactModal {
 }
 
 const ContactModal: FC<IContactModal> = ({ visible, crew, onClose, onConfirm }) => {
-  const fakeImage = faker.image.avatar()
+  const photoUrl = crew.userPhoto ? getPhotoUrl(crew.userPhoto) : null
 
   const { t } = useTranslation(['crew-screen'])
 
@@ -75,8 +75,8 @@ const ContactModal: FC<IContactModal> = ({ visible, crew, onClose, onConfirm }) 
 
           <VStack className="items-center pt-4 pb-6">
             <Box className="w-16 h-16 rounded-md bg-primary-100 overflow-hidden border-2 border-primary-200 mb-3">
-              {!!crew.userPhoto ? (
-                <RNImage source={{ uri: fakeImage }} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
+              {!!photoUrl ? (
+                <RNImage source={{ uri: photoUrl }} style={{ width: '100%', height: '100%' }} resizeMode="cover" />
               ) : (
                 <Box className="flex-1 items-center justify-center">
                   <Icon as={User} size="xl" className="text-primary-400" />

--- a/components/recruiter/crew/crewProfile/CrewContact.tsx
+++ b/components/recruiter/crew/crewProfile/CrewContact.tsx
@@ -5,7 +5,6 @@ import { MapPin, Phone, Mail, MessageCircle, Contact, Smartphone } from 'lucide-
 import { useTranslation } from 'react-i18next'
 import { SubSection, Section, SectionHeader } from '@/components/appUI'
 import { TCrew } from '@/api/types'
-import { faker } from '@faker-js/faker'
 
 const ContactSection: FC<{ crew: TCrew }> = ({ crew }) => {
   const { t } = useTranslation('crew')

--- a/components/recruiter/crew/crewProfile/CrewLanguagesAndEducation.tsx
+++ b/components/recruiter/crew/crewProfile/CrewLanguagesAndEducation.tsx
@@ -43,11 +43,13 @@ import { useTranslation } from 'react-i18next'
 import { SubSection, Section, SectionHeader } from '@/components/appUI'
 import { getAgeByYear } from '@/utils/dateUtils'
 import { TCrew } from '@/api/types'
-import { faker } from '@faker-js/faker'
 
 const LanguagesSection: FC<{ crew: TCrew }> = ({ crew }) => {
   const { t } = useTranslation(['crew-screen', 'crew'])
-  const langs = useMemo(() => [crew.language1, crew.language2, crew.language3, crew.language4].filter(Boolean), [crew])
+  const langs = useMemo(
+    () => [...new Set([crew.language1, crew.language2, crew.language3, crew.language4].filter(Boolean))],
+    [crew]
+  )
 
   return (
     <Section>

--- a/components/recruiter/crew/crewProfile/CrewPreferences.tsx
+++ b/components/recruiter/crew/crewProfile/CrewPreferences.tsx
@@ -43,7 +43,6 @@ import { useTranslation } from 'react-i18next'
 import { SubSection, Section, SectionHeader } from '@/components/appUI'
 import { getAgeByYear } from '@/utils/dateUtils'
 import { TCrew } from '@/api/types'
-import { faker } from '@faker-js/faker'
 
 const PreferencesSection: FC<{ crew: TCrew }> = ({ crew }) => {
   const { t } = useTranslation('crew')

--- a/components/recruiter/crew/crewProfile/ProfileHeader.tsx
+++ b/components/recruiter/crew/crewProfile/ProfileHeader.tsx
@@ -6,40 +6,40 @@ import { useTranslation } from 'react-i18next'
 import { Section } from '@/components/appUI'
 import { getAgeByYear } from '@/utils/dateUtils'
 import { TCrew } from '@/api/types'
-import { faker } from '@faker-js/faker'
 import { PhotoSlider } from '@/components/appUI'
 import { getCertificateOfCompetence, getSeamansBook } from '@/utils/crewUtils'
 
-const baseUrl = 'https://www.comunicazione.it/PROFoto/'
+import { getPhotoUrl } from '@/api/consts'
 
 const ProfileHeader: FC<{ crew: TCrew }> = ({ crew }) => {
   const [photoVisible, setPhotoVisible] = useState(false)
   const { t } = useTranslation(['crew-screen', 'crew'])
 
-  // const photoUrl = useMemo(() => `${baseUrl}${crew?.userPhoto}`, [crew])
-  // const photos = useMemo(
-  //   () => [crew.namephotoA, crew.namephotoB, crew.namephotoC].filter(Boolean).map((name) => `${baseUrl}${name}`),
-  //   [crew]
-  // )
-  // const primaryPhoto = photos[0]
-  // const hasPhotos = photos.length > 0
+  const photos = useMemo(
+    () =>
+      [...new Set([crew.userPhoto, crew.namephotoA, crew.namephotoB, crew.namephotoC].filter(Boolean))].map((name) =>
+        getPhotoUrl(name)
+      ),
+    [crew]
+  )
+  const primaryPhoto = photos[0] ?? null
 
-  const fakerImage1 = useMemo(() => faker.image.personPortrait({ size: 256 }), [crew])
-  const fakerImage2 = useMemo(() => faker.image.personPortrait({ size: 256 }), [crew])
-
-  const photos = useMemo(() => [fakerImage1, fakerImage2], [crew])
   const hasPhotos = photos.length > 0
   const age = getAgeByYear(crew.yearofBirth)
   const { hasCertificateOfCompetence, certificateOfCompetence } = getCertificateOfCompetence(crew)
   const hasSeamansBook = getSeamansBook(crew)
 
   return (
-    <Section className="bg-background-200 mx-0 rounded-none">
+    <Section className="mx-0 rounded-none bg-background-200">
       <VStack space="sm" className="items-center">
-        <TouchableOpacity onPress={() => setPhotoVisible(true)} activeOpacity={fakerImage1 ? 0.75 : 1}>
-          <Box className="w-28 h-28 rounded-md bg-primary-100 items-center justify-center overflow-hidden border border-outline-200">
-            {fakerImage1 ? (
-              <Image source={{ uri: fakerImage1 }} className="w-full h-full" alt="profile" />
+        <TouchableOpacity
+          onPress={() => hasPhotos && setPhotoVisible(true)}
+          activeOpacity={hasPhotos ? 0.75 : 1}
+          disabled={!hasPhotos}
+        >
+          <Box className="items-center justify-center overflow-hidden border rounded-md w-28 h-28 bg-primary-100 border-outline-200">
+            {primaryPhoto ? (
+              <Image source={{ uri: primaryPhoto }} className="w-full h-full" alt="profile" />
             ) : (
               <Icon as={User} size="xl" className="text-primary-400" />
             )}
@@ -49,7 +49,7 @@ const ProfileHeader: FC<{ crew: TCrew }> = ({ crew }) => {
             <Box className="absolute -bottom-1.5 -right-1.5 rounded-full bg-primary-500 items-center justify-center border-2 border-white px-1.5 py-1 flex-row gap-1">
               <Icon as={photos.length > 1 ? Images : Expand} size="xs" className="text-white" />
               {photos.length > 1 && (
-                <Text size="xs" bold className="text-white leading-none">
+                <Text size="xs" bold className="leading-none text-white">
                   {photos.length}
                 </Text>
               )}
@@ -59,7 +59,7 @@ const ProfileHeader: FC<{ crew: TCrew }> = ({ crew }) => {
 
         <PhotoSlider visible={photoVisible} photos={photos} onClose={() => setPhotoVisible(false)} initialIndex={0} />
         <VStack space="xs" className="items-center">
-          <Heading size="md" className="text-primary-600 text-center ">
+          <Heading size="md" className="text-center text-primary-600 ">
             {crew?.contacted === 'True' ? crew.name + ' ' + crew.surname : crew.mainPosition}
           </Heading>
           <HStack space="md">

--- a/eas.json
+++ b/eas.json
@@ -9,10 +9,16 @@
       "distribution": "internal"
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_PHOTOS_BASE_URL": "https://test.marineria.it"
+      }
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "env": {
+        "EXPO_PUBLIC_PHOTOS_BASE_URL": "https://www.marineria.it"
+      }
     }
   },
   "submit": {


### PR DESCRIPTION
## Summary
- Add `getPhotoUrl` utility in `api/consts.ts` using `EXPO_PUBLIC_PHOTOS_BASE_URL`
- Preview builds use `test.marineria.it`, production builds use `www.marineria.it`
- Remove all `@faker-js/faker` usage from crew components
- Deduplicate photos array in ProfileHeader and languages in CrewLanguagesAndEducation
- Photo thumbnail disabled when no photos available