### PR TITLE
Misc fixes: notification toggle, splash screen, API errors

### DIFF
--- a/Providers/UserProvider/UserProvider.tsx
+++ b/Providers/UserProvider/UserProvider.tsx
@@ -71,7 +71,7 @@ const UserProvider = (props: React.PropsWithChildren) => {
         pushToken && (await setPushNotificationToken(token as string, pushToken))
       }
     },
-    onSuccess: () => {
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['user', token, role] })
     },
   })

--- a/api/profile.ts
+++ b/api/profile.ts
@@ -1,7 +1,7 @@
 import { API } from './consts'
 import { TUserRole } from '@/api/types/auth'
 import { TUser } from '@/api/types/user'
-import { apiFetchJson, getLanguageCode } from './utils'
+import { apiFetchJson, apiFetchText, getLanguageCode } from './utils'
 
 export const getProUserProfile = async (token: string, role: TUserRole, language: string): Promise<TUser[]> => {
   const userRole = role == TUserRole.RECRUITER ? 'Owneruser' : 'Prouser'
@@ -21,7 +21,7 @@ export const setPushNotificationToken = async (token: string, pushToken: string)
   const url = `${API.NOTIFICATION}/SetPushNotificationToken`
   const body = JSON.stringify({ token, pushToken })
 
-  await apiFetchJson<void>(url, {
+  await apiFetchText(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json; charset=utf-8',

--- a/api/utils.ts
+++ b/api/utils.ts
@@ -22,7 +22,15 @@ export async function apiFetchJson<TResponse>(url: string, init?: ApiRequestInit
   const response = await fetch(url, init)
 
   if (!response.ok) {
-    throw new ApiError(response.status)
+    const body = await response.text().catch(() => '')
+    let message: string | undefined
+    try {
+      const parsed = JSON.parse(body)
+      message = parsed.message || parsed.title || parsed.error || body || undefined
+    } catch {
+      message = body || undefined
+    }
+    throw new ApiError(response.status, message)
   }
 
   return response.json() as Promise<TResponse>
@@ -32,7 +40,8 @@ export async function apiFetchText(url: string, init?: ApiRequestInit): Promise<
   const response = await fetch(url, init)
 
   if (!response.ok) {
-    throw new ApiError(response.status)
+    const body = await response.text().catch(() => '')
+    throw new ApiError(response.status, body || undefined)
   }
 
   return response.text()

--- a/app.json
+++ b/app.json
@@ -39,10 +39,7 @@
       [
         "expo-splash-screen",
         {
-          "backgroundColor": "#4aafc4",
-          "image": "./assets/images/splash.png",
-          "imageWidth": 200,
-          "resizeMode": "contain"
+          "backgroundColor": "#FFF5F0"
         }
       ],
       "expo-router",

--- a/app/(tabs)/settings/index.tsx
+++ b/app/(tabs)/settings/index.tsx
@@ -45,7 +45,7 @@ const Settings = () => {
 
   return (
     <ScreenContainer className="px-2">
-      <VStack className="h-full justify-between py-4">
+      <VStack className="justify-between h-full py-4">
         <VStack space="sm">
           <HStack className="justify-between items-center bg-white rounded-md p-3 mb-5 border border-background-300 min-h-[60px]">
             <HStack className="items-center" space="sm">
@@ -107,7 +107,7 @@ const Settings = () => {
             )}
           </Box>
           <Link onPress={handlePrivacyPolicy} className="self-start px-6 pb-3">
-            <LinkText className="text-primary-500 text-sm">{t('privacy-policy')}</LinkText>
+            <LinkText className="text-sm text-primary-500">{t('privacy-policy')}</LinkText>
           </Link>
         </VStack>
       </VStack>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,6 +2,7 @@ import '@/global.css'
 import '@/localization'
 import * as Sentry from '@sentry/react-native'
 import { useEffect, useState } from 'react'
+import { View } from 'react-native'
 import { Slot } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
 import * as SecureStore from 'expo-secure-store'
@@ -12,7 +13,6 @@ import { useTranslation } from 'react-i18next'
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
 import { ThemeUIProvider } from '@/components/ui/gluestack-ui-provider'
 import SessionProvider, { useSession } from '@/Providers/SessionProvider'
-import { Loading } from '@/components/ui'
 import { MarineriaSplash } from '@/components/appUI'
 
 Sentry.init({
@@ -49,7 +49,7 @@ export default Sentry.wrap(function RootLayout() {
     loadAssets()
   }, [])
 
-  if (!assetsLoaded) return <Loading />
+  if (!assetsLoaded) return <View style={{ flex: 1, backgroundColor: '#FFF5F0' }} />
 
   return (
     <ThemeUIProvider mode="light">

--- a/components/appUI/MarineriaSplash/index.tsx
+++ b/components/appUI/MarineriaSplash/index.tsx
@@ -183,7 +183,7 @@ const styles = StyleSheet.create({
     zIndex: 999,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: '#4aafc4',
+    backgroundColor: '#FFF5F0',
   },
   bg: {
     ...StyleSheet.absoluteFillObject,

--- a/components/pro/offers/offerDetails/OfferDetails.tsx
+++ b/components/pro/offers/offerDetails/OfferDetails.tsx
@@ -4,6 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { VStack } from '@/components/ui'
 import { Loading } from '@/components/ui/loading'
 import { getProOfferById, applyToOffer, getWhyCanNotApply } from '@/api'
+import { ApiError } from '@/api/utils'
 import OfferHeader from './OfferHeader'
 import OfferContract from './OfferContract'
 import OfferPosition from './OfferPosition'
@@ -68,8 +69,9 @@ export default function OfferDetailsScreen() {
         title: t('success', { ns: 'common' }),
       })
     },
-    onError: () => {
-      showToast({ emphasize: 'error', title: 'Error', description: t('unknown-error', { ns: 'common' }) })
+    onError: (error: unknown) => {
+      const message = error instanceof ApiError && error.title !== 'unknown-error' ? error.title : null
+      showToast({ emphasize: 'error', title: 'Error', description: message ?? t('unknown-error', { ns: 'common' }) })
     },
     onSettled: () => {
       queryClient.invalidateQueries({


### PR DESCRIPTION
## Summary
- Fix notification toggle not updating (use `apiFetchText` + `onSettled` refetch)
- Fix splash screen jump by removing native splash image for smooth animated handoff
- Show API error message in apply toast instead of generic fallback

## Test plan
- [ ] Toggle push notifications on/off in settings — toggle should reflect new state
- [ ] Launch app — no visual jump between native and animated splash
- [ ] Apply to an offer as unpublished user — toast should show the API reason (e.g. "user not published")